### PR TITLE
Add managed microscope connection helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,54 @@ sbwrapper --list-metadata  # List metadata record classes
 ## Python Usage
 
 ```python
-from sbwrapper import SBAccess, MicroscopeStates
+from sbwrapper import MicroscopeConnection, MicroscopeStates
 
-client = SBAccess()
-# client.Connect("127.0.0.1", 60000)  # Example connection
-print(MicroscopeStates.CurrentObjective)
+with MicroscopeConnection("127.0.0.1", 60000, keep_alive_interval=30.0) as client:
+    # Interact with the remote SlideBook instance via the SBAccess API.
+    print(MicroscopeStates.CurrentObjective)
 ```
 
-The package exposes the networking client (`SBAccess`), enumerations for
-hardware state queries, helper utilities in `sbwrapper.byte_util`, and the
-generated metadata structures under `sbwrapper.c_metadata_lib`.
+The package exposes the low-level networking client (`SBAccess`), the
+high-level `MicroscopeConnection` context manager, enumerations for hardware
+state queries, helper utilities in `sbwrapper.byte_util`, and the generated
+metadata structures under `sbwrapper.c_metadata_lib`.
+
+### Remote Connection Configuration
+
+The connection helper expects the SlideBook remote-control service to be
+enabled. Typical deployments expose the service on TCP port ``60000`` and use
+the hostname or IP address of the workstation running SlideBook. When
+credentials are required, authenticate through the returned `SBAccess` instance
+inside the context manager (for example via `client.Login(user, password)`).
+
+For repeatable automation workflows you may prefer setting environment
+variables and passing them into ``MicroscopeConnection``:
+
+```bash
+export SBWRAPPER_HOST=192.168.1.20
+export SBWRAPPER_PORT=60000
+```
+
+```python
+from sbwrapper import MicroscopeConnection
+import os
+
+conn = MicroscopeConnection(
+    os.environ["SBWRAPPER_HOST"],
+    int(os.environ.get("SBWRAPPER_PORT", "60000")),
+    keep_alive_interval=10.0,
+    keep_alive_message="PING\n",
+)
+
+with conn as client:
+    # Perform initialization commands here. The connection automatically
+    # retries transient network failures and keeps the socket alive.
+    ...
+```
+
+The connection object can be reused across threads, and calling ``close()`` or
+exiting the context manager ensures the socket is shut down and the keep-alive
+worker terminates.
 
 ## Examples and Tests
 

--- a/src/sbwrapper/__init__.py
+++ b/src/sbwrapper/__init__.py
@@ -3,6 +3,7 @@
 from . import byte_util
 from . import c_metadata_lib as _metadata_lib
 from .base_decoder import BaseDecoder
+from .connection import MicroscopeConnection
 from .csb_point import CSBPoint
 from .sb_access import MicroscopeHardwareComponent
 from .sb_access import MicroscopeStates
@@ -17,6 +18,7 @@ __all__ = [
     "SBAccess",
     "MicroscopeStates",
     "MicroscopeHardwareComponent",
+    "MicroscopeConnection",
     "BaseDecoder",
     "CSBPoint",
     "byte_util",

--- a/src/sbwrapper/connection.py
+++ b/src/sbwrapper/connection.py
@@ -1,0 +1,250 @@
+"""Connection management utilities for SBAccess clients."""
+from __future__ import annotations
+
+import logging
+import socket
+import threading
+import time
+from typing import Callable, Optional
+
+from .sb_access import SBAccess
+
+LOGGER = logging.getLogger(__name__)
+
+
+class MicroscopeConnection:
+    """High level connection helper for :class:`~sbwrapper.sb_access.SBAccess`.
+
+    Parameters
+    ----------
+    host:
+        Hostname or IP address of the SB server.
+    port:
+        TCP port of the SB server.
+    connect_timeout:
+        Socket creation timeout in seconds passed to
+        :func:`socket.create_connection`.
+    read_timeout:
+        Optional per-operation timeout in seconds applied to the socket
+        after it is created.
+    reconnect_attempts:
+        How many times to attempt reconnecting before failing. ``1`` means
+        a single attempt without retries.
+    reconnect_delay:
+        Delay in seconds between reconnect attempts.
+    keep_alive_interval:
+        If provided, enables a keep-alive worker that periodically invokes
+        ``keep_alive_callback`` or sends ``keep_alive_message``.
+    keep_alive_message:
+        Raw bytes (or UTF-8 string) to transmit for keep-alive when no
+        callback is supplied.
+    keep_alive_callback:
+        Optional callable ``callback(client)`` executed for keep-alive
+        checks. Exceptions raised by the callback trigger reconnection
+        attempts.
+    on_reconnect:
+        Optional callable ``callback(client)`` executed after a successful
+        reconnection. Exceptions are logged but ignored.
+    auto_reconnect:
+        Enables automatic reconnects when communication errors are detected.
+    socket_factory:
+        Custom factory returning a connected socket. Defaults to
+        :func:`socket.create_connection`.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        *,
+        connect_timeout: float | None = 5.0,
+        read_timeout: float | None = None,
+        reconnect_attempts: int = 3,
+        reconnect_delay: float = 1.0,
+        keep_alive_interval: float | None = None,
+        keep_alive_message: bytes | str | None = None,
+        keep_alive_callback: Callable[[SBAccess], None] | None = None,
+        on_reconnect: Callable[[SBAccess], None] | None = None,
+        auto_reconnect: bool = True,
+        socket_factory: Callable[[tuple[str, int], Optional[float]], socket.socket]
+        | None = None,
+    ) -> None:
+        if reconnect_attempts < 1:
+            raise ValueError("reconnect_attempts must be >= 1")
+        self.host = host
+        self.port = port
+        self.connect_timeout = connect_timeout
+        self.read_timeout = read_timeout
+        self.reconnect_attempts = reconnect_attempts
+        self.reconnect_delay = reconnect_delay
+        if keep_alive_interval is not None and keep_alive_interval <= 0:
+            raise ValueError("keep_alive_interval must be positive when provided")
+        self.keep_alive_interval = keep_alive_interval
+        self._keep_alive_message = keep_alive_message
+        self._keep_alive_callback = keep_alive_callback
+        self._on_reconnect = on_reconnect
+        self.auto_reconnect = auto_reconnect
+        self._socket_factory = socket_factory or socket.create_connection
+
+        self._lock = threading.RLock()
+        self._socket: socket.socket | None = None
+        self.client: SBAccess | None = None
+        self._keep_alive_thread: threading.Thread | None = None
+        self._keep_alive_event: threading.Event | None = None
+        self._closing = False
+
+    # ------------------------------------------------------------------
+    # context manager helpers
+    def __enter__(self) -> SBAccess:
+        return self.connect()
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    # ------------------------------------------------------------------
+    def connect(self) -> SBAccess:
+        """Establish a socket connection and create an :class:`SBAccess`.
+
+        Returns
+        -------
+        SBAccess
+            Connected SBAccess client instance.
+
+        Raises
+        ------
+        ConnectionError
+            If the connection cannot be established.
+        """
+
+        with self._lock:
+            if self.client is not None and self._socket is not None:
+                return self.client
+
+        attempt_error: Exception | None = None
+        for attempt in range(1, self.reconnect_attempts + 1):
+            sock: socket.socket | None = None
+            try:
+                LOGGER.debug(
+                    "Connecting to %s:%s (attempt %s)",
+                    self.host,
+                    self.port,
+                    attempt,
+                )
+                sock = self._socket_factory((self.host, self.port), self.connect_timeout)
+                if self.read_timeout is not None:
+                    sock.settimeout(self.read_timeout)
+                client = SBAccess(sock)
+                with self._lock:
+                    self._socket = sock
+                    self.client = client
+                    self._closing = False
+                    self._start_keep_alive()
+                    return client
+            except Exception as exc:  # pragma: no cover - error logging path
+                attempt_error = exc
+                LOGGER.warning(
+                    "Connection attempt %s to %s:%s failed: %s",
+                    attempt,
+                    self.host,
+                    self.port,
+                    exc,
+                )
+                if sock is not None:
+                    try:
+                        sock.close()
+                    except Exception:  # pragma: no cover - best effort cleanup
+                        pass
+                if attempt < self.reconnect_attempts:
+                    time.sleep(self.reconnect_delay)
+        message = f"Unable to connect to {self.host}:{self.port}"
+        raise ConnectionError(message) from attempt_error
+
+    # ------------------------------------------------------------------
+    def close(self) -> None:
+        """Close the underlying socket and stop keep-alive processing."""
+
+        with self._lock:
+            self._closing = True
+            event = self._keep_alive_event
+            thread = self._keep_alive_thread
+            self._keep_alive_event = None
+            self._keep_alive_thread = None
+        if event is not None:
+            event.set()
+        if thread is not None:
+            thread.join(timeout=1.0)
+        with self._lock:
+            self._teardown_connection()
+            self._closing = False
+
+    # ------------------------------------------------------------------
+    def _teardown_connection(self) -> None:
+        if self.client is not None:
+            LOGGER.debug("Tearing down SBAccess client")
+        sock = self._socket
+        self.client = None
+        self._socket = None
+        if sock is not None:
+            try:
+                sock.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            finally:
+                sock.close()
+
+    # ------------------------------------------------------------------
+    def _start_keep_alive(self) -> None:
+        if self.keep_alive_interval is None:
+            return
+        with self._lock:
+            if self._keep_alive_thread and self._keep_alive_thread.is_alive():
+                return
+            self._keep_alive_event = threading.Event()
+            self._keep_alive_thread = threading.Thread(
+                target=self._keep_alive_worker,
+                name="MicroscopeConnectionKeepAlive",
+                daemon=True,
+            )
+            self._keep_alive_thread.start()
+
+    # ------------------------------------------------------------------
+    def _keep_alive_worker(self) -> None:
+        assert self._keep_alive_event is not None
+        event = self._keep_alive_event
+        while not event.wait(self.keep_alive_interval or 0.0):
+            with self._lock:
+                client = self.client
+                sock = self._socket
+            if client is None or sock is None:
+                continue
+            try:
+                if self._keep_alive_callback is not None:
+                    self._keep_alive_callback(client)
+                elif self._keep_alive_message is not None:
+                    message = (
+                        self._keep_alive_message.encode("utf-8")
+                        if isinstance(self._keep_alive_message, str)
+                        else self._keep_alive_message
+                    )
+                    sock.sendall(message)
+            except Exception as exc:  # pragma: no cover - keep alive failure path
+                LOGGER.warning("Keep-alive failed: %s", exc)
+                self._handle_connection_drop(exc)
+
+    # ------------------------------------------------------------------
+    def _handle_connection_drop(self, error: Exception) -> None:
+        LOGGER.error("Connection to %s:%s dropped: %s", self.host, self.port, error)
+        self._teardown_connection()
+        if self._closing or not self.auto_reconnect:
+            return
+        try:
+            client = self.connect()
+        except ConnectionError:
+            LOGGER.exception("Automatic reconnection failed")
+        else:
+            if self._on_reconnect is not None:
+                try:
+                    self._on_reconnect(client)
+                except Exception:  # pragma: no cover - callback failure path
+                    LOGGER.exception("Reconnection callback failed")
+

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import threading
+from typing import List
+
+import pytest
+
+from sbwrapper import MicroscopeConnection
+import sbwrapper.connection as connection_module
+
+
+class DummySocket:
+    def __init__(self) -> None:
+        self.timeout = None
+        self.shutdown_called = False
+        self.closed = False
+        self.sent: List[bytes] = []
+
+    def settimeout(self, timeout):
+        self.timeout = timeout
+
+    def shutdown(self, how):  # pragma: no cover - platform dependent
+        self.shutdown_called = True
+
+    def close(self):
+        self.closed = True
+
+    def sendall(self, data: bytes):
+        self.sent.append(data)
+
+
+class FakeSBAccess:
+    def __init__(self, sock):
+        self.sock = sock
+
+
+@pytest.fixture(autouse=True)
+def patch_sbaccess(monkeypatch):
+    monkeypatch.setattr(connection_module, "SBAccess", FakeSBAccess)
+    yield
+
+
+def test_context_manager_handles_connection_lifecycle():
+    socket_instance = DummySocket()
+
+    def socket_factory(address, timeout):
+        assert address == ("localhost", 1234)
+        assert timeout == 1.0
+        return socket_instance
+
+    conn = MicroscopeConnection(
+        "localhost",
+        1234,
+        connect_timeout=1.0,
+        read_timeout=2.0,
+        socket_factory=socket_factory,
+    )
+
+    with conn as client:
+        assert client.sock is socket_instance
+        assert socket_instance.timeout == 2.0
+    assert socket_instance.closed is True
+    assert conn.client is None
+
+
+def test_reconnect_callback_invoked_on_drop():
+    sockets = [DummySocket(), DummySocket()]
+
+    def socket_factory(address, timeout):
+        return sockets.pop(0)
+
+    reconnection_event = threading.Event()
+
+    def on_reconnect(client):
+        assert isinstance(client, FakeSBAccess)
+        reconnection_event.set()
+
+    conn = MicroscopeConnection(
+        "localhost",
+        1234,
+        reconnect_attempts=2,
+        reconnect_delay=0.01,
+        socket_factory=socket_factory,
+        on_reconnect=on_reconnect,
+    )
+
+    first_client = conn.connect()
+    assert isinstance(first_client, FakeSBAccess)
+    # Simulate a connection drop from a worker.
+    conn._handle_connection_drop(RuntimeError("boom"))
+
+    assert reconnection_event.wait(1.0), "Reconnection callback not triggered"
+    assert conn.client is not None
+    conn.close()
+
+
+def test_keep_alive_sends_message_until_closed():
+    socket_instance = DummySocket()
+    send_event = threading.Event()
+
+    def socket_factory(address, timeout):
+        return socket_instance
+
+    original_sendall = socket_instance.sendall
+
+    def sendall(data):
+        original_sendall(data)
+        send_event.set()
+
+    socket_instance.sendall = sendall
+
+    conn = MicroscopeConnection(
+        "localhost",
+        1234,
+        socket_factory=socket_factory,
+        keep_alive_interval=0.05,
+        keep_alive_message=b"ping",
+    )
+
+    conn.connect()
+    assert send_event.wait(1.0), "Keep-alive message was not sent"
+    conn.close()
+    assert socket_instance.closed is True


### PR DESCRIPTION
## Summary
- add a MicroscopeConnection helper that wraps SBAccess sockets with retries, keep-alive, and context manager support
- expose the helper from the public package interface and document connection configuration guidance
- add unit tests that exercise the connection lifecycle, reconnection callback, and keep-alive messaging

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3da4be6048326aa99cfedefea226a