### PR TITLE
Maintain persistent microscope client connections

### DIFF
--- a/src/microscope_client.py
+++ b/src/microscope_client.py
@@ -68,6 +68,13 @@ class MicroscopeClient:
         self.sb = None
         logging.info("Disconnected from microscope")
 
+    def is_healthy(self) -> bool:
+        """Return ``True`` when the socket and SBAccess handle are usable."""
+        if not self.sock or not self.sb:
+            return False
+        closed = getattr(self.sock, "_closed", True)
+        return not closed
+
     def fetch_points(self) -> List[Point]:
         """Return all current XYZ points from SlideBook."""
         if not self.sb:


### PR DESCRIPTION
## Summary
- add an `is_healthy` helper to `MicroscopeClient` so callers can detect dropped sockets
- refactor `MicroscopeService` to manage a shared client with connect/disconnect helpers and automatic reconnection
- update microscope service tests with reusable fake clients and a regression that checks client reuse

## Testing
- pytest test_microscope_service.py

------
https://chatgpt.com/codex/tasks/task_e_68e52c4169248326baebd4d39b3b50d4