### PR TITLE
Replace environment configuration with config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,18 @@ without going through HTTP.
    ```bash
    python -m src
    ```
- The server looks for static files in `frontend/`.  Set the environment
-  variable `SBS_FRONTEND_DIR` to serve a different front-end directory or omit
-  the folder entirely to use only the backend API.
+ The server looks for static files in `frontend/`.  Update the
+  ``frontend.directory`` entry in ``config.yaml`` to serve a different
+  front-end directory or omit the folder entirely to use only the backend API.
+
+## Configuration
+
+Runtime settings live in ``config.yaml`` at the repository root.  The default
+file configures the microscope connection (``microscope.host`` and
+``microscope.port``), the optional static frontend
+(``frontend.directory``), and the object-detection weights
+(``detection.yolo_model``).  Adjust these values to match your deployment
+environment and restart the server for changes to take effect.
 
 ## Programmatic use
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,18 @@
+# Default configuration for SB Wrapper.  Adjust the values to match the
+# environment where the application runs.
+frontend:
+  # Directory containing the compiled front-end assets served by the FastAPI
+  # application.  Leave as ``null`` to fall back to the bundled static files.
+  directory: null
+
+microscope:
+  # Hostname or IP address for the SlideBook/SlideBook Server connection.
+  host: 127.0.0.1
+  # TCP port used by the microscope server.
+  port: 65432
+
+# Settings used by the YOLO object detection helper.
+detection:
+  # Optional path to a custom YOLO weight file.  ``null`` falls back to the
+  # bundled model weights.
+  yolo_model: null

--- a/src/configuration.py
+++ b/src/configuration.py
@@ -1,0 +1,91 @@
+"""Central configuration helpers for SB Wrapper."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+# The default configuration file ships with the project root.  Deployments can
+# replace the values in ``config.yaml`` with local settings.
+_DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[1] / "config.yaml"
+
+# Cached configuration loaded from disk.  The file is only read once per
+# process unless :func:`reload_settings` is called.
+_file_settings: Optional[Mapping[str, Any]] = None
+
+# Stack of in-memory overrides.  These are primarily intended for tests where
+# we want predictable configuration without touching the on-disk file.
+_override_stack: list[Mapping[str, Any]] = []
+
+
+def _load_from_file(path: Path) -> Mapping[str, Any]:
+    """Return the configuration mapping stored at ``path``."""
+
+    if not path.exists():
+        return {}
+
+    with path.open("r", encoding="utf-8") as handle:
+        loaded = yaml.safe_load(handle) or {}
+
+    if not isinstance(loaded, Mapping):
+        raise ValueError("Configuration file must contain a mapping at the top level")
+
+    return loaded
+
+
+def reload_settings() -> None:
+    """Clear the cached configuration so it is re-read from disk."""
+
+    global _file_settings
+    _file_settings = None
+
+
+def reset_overrides() -> None:
+    """Remove any active in-memory configuration overrides."""
+
+    _override_stack.clear()
+
+
+@contextmanager
+def override_settings(settings: Mapping[str, Any]) -> Iterator[None]:
+    """Temporarily replace configuration values within a context block."""
+
+    _override_stack.append(settings)
+    try:
+        yield
+    finally:
+        _override_stack.pop()
+
+
+def _active_settings() -> Mapping[str, Any]:
+    """Return the currently active configuration mapping."""
+
+    if _override_stack:
+        return _override_stack[-1]
+
+    global _file_settings
+    if _file_settings is None:
+        _file_settings = _load_from_file(_DEFAULT_CONFIG_PATH)
+
+    return _file_settings
+
+
+def get_setting(path: str, default: Optional[Any] = None) -> Any:
+    """Fetch a configuration value using a dotted ``path`` notation."""
+
+    if not path:
+        return _active_settings()
+
+    value: Any = _active_settings()
+    for segment in path.split("."):
+        if not isinstance(value, Mapping) or segment not in value:
+            return default
+        value = value[segment]
+        if value is None:
+            return default
+
+    return value

--- a/src/interfaces/web/app.py
+++ b/src/interfaces/web/app.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import argparse
 import logging
-import os
 from pathlib import Path
 
 from fastapi import FastAPI
 
 from .api_router import router as api_router
 from .static_ui import include_static_ui
+from ...configuration import get_setting
 
 logging.basicConfig(level=logging.INFO)
 
@@ -18,9 +18,9 @@ logging.basicConfig(level=logging.INFO)
 def _resolve_frontend_dir() -> Path:
     """Return the configured frontend directory path."""
 
-    configured = os.environ.get("SBS_FRONTEND_DIR")
+    configured = get_setting("frontend.directory")
     if configured:
-        return Path(configured)
+        return Path(str(configured)).expanduser()
     return Path(__file__).resolve().parents[2] / "frontend"
 
 


### PR DESCRIPTION
## Summary
- add a version-controlled `config.yaml` and helper module for loading runtime settings
- switch the FastAPI app, microscope service, and YOLO helper to read configuration from the new file instead of environment variables
- document the new configuration workflow and update tests to exercise the file-based overrides

## Testing
- pytest test_webapp_factory.py

------
https://chatgpt.com/codex/tasks/task_e_68e53c5857a48326b48946cb8150338f